### PR TITLE
Added multiple PowerRouters to the webinterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # powerinterface
 
-This is a simple web interface that shows statistics about your Nedap PowerRouter. It aims to serve as a self-hosted replacement for the discontinued mypowerrouter.com interface.
+This is a simple web interface that shows statistics about your Nedap PowerRouters. It aims to serve as a self-hosted replacement for the discontinued mypowerrouter.com interface.
 
 ## Features
 
-- Show current PowerRouter stats of your PowerRouter
+- Show current PowerRouter stats of multiple PowerRouters
 - Forward data to an InfluxDB
 
 ## Documentation
@@ -50,7 +50,7 @@ Enter `http://[IP of your devie running Powerinterface]` in your browser. You sh
 
 #### Install without Docker / run from source
 
-Make sure to have NodeJS and Git installed.
+Make sure to have NodeJS (>=12) and Git installed.
 
 ```bash
 git clone https://github.com/ngrie/powerinterface.git
@@ -121,8 +121,8 @@ actions:
     port: 8086
 ```
 
-Of course, adjust host, database, username, password and port as needed (if you run InfluxDB on the same device without changing any configs the above values should work).
+Of course, adjust host, database, username, password and port as needed (if you run InfluxDB on the same device without changing any configs the above values should work). If you're using Powerinterface with Docker localhost (127.0.0.1) doesn't work here because the Docker container runs in its own separated environment. Because of that you have to give the local ip address of the device.
 
-If you installed Powerinterface using Docker, edit `docker-compose.yml` and uncomment (remove the `#`) the last four lines.
+If you installed Powerinterface using Docker, edit `docker-compose.yml` and uncomment (remove the `#`) the last four lines. Then you need to update your Docker container with `docker-compose up -d`
 
 Afterwards, restart Powerinterface (Docker: `docker-compose restart`, systemd: `systemctl restart powerinterface`).

--- a/server.js
+++ b/server.js
@@ -72,6 +72,7 @@ app.use(morgan('combined'))
 let updateAvailable = false
 let powerRouters = new Map()
 
+// creates and initializes new powerrouter object and stores it in a map
 const addNewPowerRouter = (powerRouterId) => {
   let powerRouter = {}
   powerRouter.powerRouterId = powerRouterId
@@ -88,18 +89,22 @@ const addNewPowerRouter = (powerRouterId) => {
 runUpdateCheck(CURRENT_VERSION, () => updateAvailable = true)
 
 app.get('/', (req, res) => {
+  // get the powerrouter ID from url query
+  // change the powerrouter ID to the first one which sent data already when no query is given
   let powerRouterId = req.query.powerRouterId
   if (powerRouters.size > 0 && powerRouterId === undefined) {
     powerRouterId = powerRouters.keys().next().value
   }
 
   if (powerRouters.has(powerRouterId)) {
+    // show webinterface with data of the correct powerrouter
     let powerRouter = powerRouters.get(powerRouterId)
     res.send(buildWebinterface(powerRouterId, powerRouters.keys(), powerRouter.currentData, powerRouter.stats, {
       isWinterMode:powerRouter.isWinterMode,
       isMaintenanceCharge:powerRouter.isMaintenanceCharge
     }, {webReload}, powerRouter.lastUpdate, updateAvailable))
   } else {
+    // show no data page and selected, available IDs when available if no powerrouter sent data or this ID isn't known
     let powerRouterIds = powerRouters.size > 0 ? powerRouters.keys() : null
     res.send(buildWebinterface(powerRouterId, powerRouterIds, {}, initStats(), {
       isWinterMode:false,
@@ -109,40 +114,52 @@ app.get('/', (req, res) => {
 })
 
 app.get('/values.json', (req, res) => {
+  // get the powerrouter ID from url query
+  // change the powerrouter ID to the first one which sent data already when no query is given
   let powerRouterId = req.query.powerRouterId
   if (powerRouters.size > 0 && powerRouterId === undefined) {
     powerRouterId = powerRouters.keys().next().value
   }
 
   if (powerRouters.has(powerRouterId)) {
+    // send current data of the correct ID in json format
     res.type('json').send(powerRouters.get(powerRouterId).currentData)
   } else {
+    // send empty object if no powerrouter sent data or this ID isn't known
     res.type('json').send({})
   }
 })
 
 app.get('/status.json', (req, res) => {
+  // get the powerrouter ID from url query
+  // change the powerrouter ID to the first one which sent data already when no query is given
   let powerRouterId = req.query.powerRouterId
   if (powerRouters.size > 0 && powerRouterId === undefined) {
     powerRouterId = powerRouters.keys().next().value
   }
 
   if (powerRouters.has(powerRouterId)) {
+    // send current status of the correct ID in json format
     res.type('json').send(powerRouters.get(powerRouterId).currentStatuses)
   } else {
+    // send empty object if no powerrouter sent data or this ID isn't known
     res.type('json').send({})
   }
 })
 
 app.get('/events.json', (req, res) => {
+  // get the powerrouter ID from url query
+  // change the powerrouter ID to the first one which sent data already when no query is given
   let powerRouterId = req.query.powerRouterId
   if (powerRouters.size > 0 && powerRouterId === undefined) {
     powerRouterId = powerRouters.keys().next().value
   }
 
   if (powerRouters.has(powerRouterId)) {
+    // send events list of the correct ID in json format
     res.type('json').send([...powerRouters.get(powerRouterId).events].reverse())
   } else {
+    // send empty list if no powerrouter sent data or this ID isn't known
     res.type('json').send([])
   }
 })
@@ -154,6 +171,7 @@ app.post('/logs.json', (req, res) => {
     if (!powerRouters.has(powerRouterId)) {
       addNewPowerRouter(powerRouterId)
     }
+    // update the correct powerrouter with the newly received data
     let powerRouter = powerRouters.get(powerRouterId)
     powerRouter.currentData = data
     powerRouter.currentStatuses = statuses
@@ -200,6 +218,7 @@ app.post('/events.json', (req, res) => {
     if (!powerRouters.has(powerRouterId)) {
       addNewPowerRouter(powerRouterId)
     }
+    // update the correct powerrouter with the newly received data
     let powerRouter = powerRouters.get(powerRouterId)
     powerRouter.isWinterMode = isWinterMode
     powerRouter.isMaintenanceCharge = isMaintenanceCharge

--- a/server.js
+++ b/server.js
@@ -77,7 +77,7 @@ runUpdateCheck(CURRENT_VERSION, () => updateAvailable = true)
 app.get('/', (req, res) => {
   let powerRouterId = req.query.powerRouterId
   console.log('PowerRouter ID: ', powerRouterId)
-  if (!powerRouters.has(powerRouterId)) {
+  if (powerRouters.has(powerRouterId)) {
     let powerRouter = powerRouters.get(powerRouterId)
     let isWinterMode = powerRouter.isWinterMode
     let isMaintenanceCharge = powerRouter.isMaintenanceCharge

--- a/server.js
+++ b/server.js
@@ -76,25 +76,25 @@ runUpdateCheck(CURRENT_VERSION, () => updateAvailable = true)
 
 app.get('/', (req, res) => {
   let powerRouterId = req.query.powerRouterId
-  console.log('PowerRouter ID: ', powerRouterId)
   if (powerRouters.has(powerRouterId)) {
     let powerRouter = powerRouters.get(powerRouterId)
     let isWinterMode = powerRouter.isWinterMode
     let isMaintenanceCharge = powerRouter.isMaintenanceCharge
-    res.send(buildWebinterface(powerRouter.currentData, powerRouter.stats, {
+    res.send(buildWebinterface(powerRouterId, powerRouters.keys(), powerRouter.currentData, powerRouter.stats, {
       isWinterMode,
       isMaintenanceCharge
     }, {webReload}, powerRouter.lastUpdate, updateAvailable))
   } else if (powerRouters.size > 0 && powerRouterId === undefined) {
-    let powerRouter = powerRouters.values().next().value
+    let powerRouterId = powerRouters.keys().next().value
+    let powerRouter = powerRouters.get(powerRouterId)
     let isWinterMode = powerRouter.isWinterMode
     let isMaintenanceCharge = powerRouter.isMaintenanceCharge
-    res.send(buildWebinterface(powerRouter.currentData, powerRouter.stats, {
+    res.send(buildWebinterface(powerRouterId, powerRouters.keys(), powerRouter.currentData, powerRouter.stats, {
       isWinterMode,
       isMaintenanceCharge
     }, {webReload}, powerRouter.lastUpdate, updateAvailable))
   } else {
-    res.send(buildWebinterface({}, initStats(), {
+    res.send(buildWebinterface(null, null, {}, initStats(), {
       isWinterMode:false,
       isMaintenanceCharge:false
     }, {webReload}, null, updateAvailable))
@@ -135,9 +135,10 @@ app.post('/logs.json', (req, res) => {
     if (!powerRouters.has(powerRouterId)) {
       let powerRouter = {}
       powerRouter.powerRouterId = powerRouterId
+      powerRouter.events = []
       powerRouters.set(powerRouterId, powerRouter)
     }
-    let powerRouter = powerRouters.get(powerRouterId)  // null  {}
+    let powerRouter = powerRouters.get(powerRouterId)
     powerRouter.stats = initStats()
     powerRouter.currentData = data
     powerRouter.currentStatuses = statuses

--- a/server.js
+++ b/server.js
@@ -85,7 +85,7 @@ app.get('/', (req, res) => {
       isWinterMode,
       isMaintenanceCharge
     }, {webReload}, powerRouter.lastUpdate, updateAvailable))
-  } else if (powerRouters.size > 0) {
+  } else if (powerRouters.size > 0 && powerRouterId === undefined) {
     let powerRouter = powerRouters.values().next().value
     let isWinterMode = powerRouter.isWinterMode
     let isMaintenanceCharge = powerRouter.isMaintenanceCharge
@@ -103,7 +103,7 @@ app.get('/', (req, res) => {
 
 app.get('/values.json', (req, res) => {
   let powerRouterId = req.query.powerRouterId
-  if (!powerRouters.has(powerRouterId)) {
+  if (powerRouters.has(powerRouterId)) {
     res.type('json').send(powerRouters.get(powerRouterId).currentData)
   } else {
     res.type('json').send({})
@@ -112,7 +112,7 @@ app.get('/values.json', (req, res) => {
 
 app.get('/status.json', (req, res) => {
   let powerRouterId = req.query.powerRouterId
-  if (!powerRouters.has(powerRouterId)) {
+  if (powerRouters.has(powerRouterId)) {
     res.type('json').send(powerRouters.get(powerRouterId).currentStatuses)
   } else {
     res.type('json').send({})
@@ -121,7 +121,7 @@ app.get('/status.json', (req, res) => {
 
 app.get('/events.json', (req, res) => {
   let powerRouterId = req.query.powerRouterId
-  if (!powerRouters.has(powerRouterId)) {
+  if (powerRouters.has(powerRouterId)) {
     res.type('json').send([...powerRouters.get(powerRouterId).events].reverse())
   } else {
     res.type('json').send([])
@@ -149,7 +149,7 @@ app.post('/logs.json', (req, res) => {
 
     actions.forEach((action, index) => {
       try {
-        action.update({ data, powerRouterID })
+        action.update({ data, powerRouterId })
       } catch (e) {
         console.error(`Failed to invoke action at index ${index}`, e)
       }

--- a/src/webinterface.js
+++ b/src/webinterface.js
@@ -20,7 +20,7 @@ const buildPowerRouterIds = (powerRouterIds) => {
     for (let powerRouterId of powerRouterIds) {
         powerRouterIdsString = powerRouterIdsString + '<a href="/?powerRouterId=' + powerRouterId + '" target="_blank">' + powerRouterId + '</a>' + ', '
     }
-    powerRouterIdsString.slice(0, -2)
+    powerRouterIdsString = powerRouterIdsString.slice(0, -2)
     return powerRouterIdsString
 }
 
@@ -172,8 +172,8 @@ const buildNoDataMessage = () => `
 
 const buildWebinterface = (powerRouterId, powerRouterIds, data, stats, status, config, lastUpdate, updateAvailable = false) => `
 ${buildHeader()}
-${lastUpdate ? '<p>Aktuelle Powerrouter ID: ${powerRouterId}</p>' : ''}
-${lastUpdate ? '<p>Verfügbare Powerrouter IDs: ${buildPowerRouterIds(powerRouterIds)}</p>' : ''}
+${lastUpdate ? '<p>Aktuelle Powerrouter ID: ' + powerRouterId + '</p>' : ''}
+${lastUpdate ? '<p>Verfügbare Powerrouter IDs: ' + buildPowerRouterIds(powerRouterIds) + '</p>' : ''}
 ${lastUpdate ? buildTable(data, stats, status) : buildNoDataMessage()}
 ${buildFooter(lastUpdate, updateAvailable, config.webReload)}
 `

--- a/src/webinterface.js
+++ b/src/webinterface.js
@@ -15,6 +15,7 @@ const buildStatsMonthlyLabel = (stats) => `seit ${stats.dataSince.monthly.toLoca
   { day: '2-digit', month:'2-digit' }
 )}`
 
+// build a string with links to all given powerrouter IDs
 const buildPowerRouterIds = (powerRouterIds) => {
     let powerRouterIdsString = ''
     for (let powerRouterId of powerRouterIds) {

--- a/src/webinterface.js
+++ b/src/webinterface.js
@@ -15,6 +15,15 @@ const buildStatsMonthlyLabel = (stats) => `seit ${stats.dataSince.monthly.toLoca
   { day: '2-digit', month:'2-digit' }
 )}`
 
+const buildPowerRouterIds = (powerRouterIds) => {
+    let powerRouterIdsString = ''
+    for (let powerRouterId of powerRouterIds) {
+        powerRouterIdsString = powerRouterIdsString + '<a href="/?powerRouterId=' + powerRouterId + '" target="_blank">' + powerRouterId + '</a>' + ', '
+    }
+    powerRouterIdsString.slice(0, -2)
+    return powerRouterIdsString
+}
+
 const buildHeader = () => `<!DOCTYPE html>
 <html lang="de">
   <head>
@@ -161,8 +170,10 @@ const buildNoDataMessage = () => `
 </div>
 `
 
-const buildWebinterface = (data, stats, status, config, lastUpdate, updateAvailable = false) => `
+const buildWebinterface = (powerRouterId, powerRouterIds, data, stats, status, config, lastUpdate, updateAvailable = false) => `
 ${buildHeader()}
+${lastUpdate ? '<p>Aktuelle Powerrouter ID: ${powerRouterId}</p>' : ''}
+${lastUpdate ? '<p>Verfügbare Powerrouter IDs: ${buildPowerRouterIds(powerRouterIds)}</p>' : ''}
 ${lastUpdate ? buildTable(data, stats, status) : buildNoDataMessage()}
 ${buildFooter(lastUpdate, updateAvailable, config.webReload)}
 `

--- a/src/webinterface.js
+++ b/src/webinterface.js
@@ -172,8 +172,8 @@ const buildNoDataMessage = () => `
 
 const buildWebinterface = (powerRouterId, powerRouterIds, data, stats, status, config, lastUpdate, updateAvailable = false) => `
 ${buildHeader()}
-${lastUpdate ? '<p>Aktuelle Powerrouter ID: ' + powerRouterId + '</p>' : ''}
-${lastUpdate ? '<p>Verfügbare Powerrouter IDs: ' + buildPowerRouterIds(powerRouterIds) + '</p>' : ''}
+${powerRouterId ? '<p>Aktuelle Powerrouter ID: ' + powerRouterId + '</p>' : ''}
+${powerRouterIds ? '<p>Verfügbare Powerrouter IDs: ' + buildPowerRouterIds(powerRouterIds) + '</p>' : ''}
 ${lastUpdate ? buildTable(data, stats, status) : buildNoDataMessage()}
 ${buildFooter(lastUpdate, updateAvailable, config.webReload)}
 `


### PR DESCRIPTION
The data of different powerrouter IDs is now stored separetly in order to show the data of each powerrouter individually on its own site in the webinterface. You can give the powerRouterId as a query parameter after the normal url like this ```/?powerRouterId=NOT0THE0REAL0ONE``` to get the webinterface of the powerrouter with that ID. If the query parameter isn't given the webinterface shows the powerrouter that first sent data.
The actual powerrouter ID and links to all available IDs are shown at the top of the webinterface.
The query parameter works also in the same way for the values/status/events.json pages.

Updated README with some helpful information for the docker installation.